### PR TITLE
Fix/use file storage

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GibTalk",
     "slug": "GibTalk",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "landscape",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/src/appState/storage.ts
+++ b/src/appState/storage.ts
@@ -1,50 +1,91 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as FileSystem from "expo-file-system";
 import { Alert } from "react-native";
 import { useState, useEffect } from "react";
 
-async function storeData<T>(key: string, updatedData: T): Promise<void> {
+async function readFromFile<T>(key: string): Promise<T | null> {
   try {
-    const jsonValue = JSON.stringify(updatedData);
-    await AsyncStorage.setItem(key, jsonValue);
+    const fileUri = `${FileSystem.documentDirectory}/${key}-data.json`;
+    const jsonValue = await FileSystem.readAsStringAsync(fileUri);
+    if (!jsonValue) {
+      return null;
+    }
+
+    const data = JSON.parse(jsonValue) as T;
+    if (Array.isArray(data) && !data.length) {
+      return null;
+    }
+
+    return data;
   } catch (error) {
     console.log(error);
-    let message =
-      error instanceof Error
-        ? `${error.name} - ${error.message}`
-        : "Unknown error";
-
-    Alert.alert("Store Data Error", message, [
-      { text: "OK", onPress: () => console.log("OK Pressed") },
-    ]);
-
-    throw error;
+    return null;
   }
 }
 
-async function readData<T>(key: string): Promise<T | null> {
+async function readFromAsyncStore<T>(key: string): Promise<T | null> {
   try {
     const jsonValue = await AsyncStorage.getItem(key);
     if (!jsonValue) {
       return null;
     }
 
-    return JSON.parse(jsonValue) as T;
+    const data = JSON.parse(jsonValue) as T;
+    if (Array.isArray(data) && !data.length) {
+      return null;
+    }
+
+    return data;
   } catch (error) {
     console.log(error);
-    let message =
+    throw error;
+  }
+}
+
+async function writeToFile<T>(key: string, updatedData: T): Promise<void> {
+  try {
+    const fileUri = `${FileSystem.documentDirectory}/${key}-data.json`;
+    const jsonValue = JSON.stringify(updatedData);
+
+    await FileSystem.writeAsStringAsync(fileUri, jsonValue);
+  } catch (error) {
+    console.log(error);
+    const message =
       error instanceof Error
         ? `${error.name} - ${error.message}`
         : "Unknown error";
 
-    Alert.alert("Read Data Error", message, [
-      { text: "OK", onPress: () => console.log("OK Pressed") },
+    Alert.alert("Write Data Error", message, [
+      { text: "OK", onPress: () => {} },
     ]);
 
     throw error;
   }
 }
 
-export function useStorage<T>(
+async function writeToAsyncStore<T>(
+  key: string,
+  updatedData: T,
+): Promise<void> {
+  try {
+    const jsonValue = JSON.stringify(updatedData);
+    await AsyncStorage.setItem(key, jsonValue);
+  } catch (error) {
+    console.log(error);
+    const message =
+      error instanceof Error
+        ? `${error.name} - ${error.message}`
+        : "Unknown error";
+
+    Alert.alert("Write Data Error", message, [
+      { text: "OK", onPress: () => {} },
+    ]);
+
+    throw error;
+  }
+}
+
+export function useAsyncStorage<T>(
   key: string,
   data: T,
   setData: (data: T) => void,
@@ -53,7 +94,7 @@ export function useStorage<T>(
 
   useEffect(() => {
     const doLoadData = async () => {
-      const loadedData = await readData<T>(key);
+      const loadedData = await readFromAsyncStore<T>(key);
       if (loadedData) {
         setData(loadedData);
       }
@@ -66,7 +107,48 @@ export function useStorage<T>(
 
   useEffect(() => {
     const doStoreData = async () => {
-      await storeData<T>(key, data);
+      await writeToAsyncStore<T>(key, data);
+    };
+
+    doStoreData();
+  }, [data]);
+
+  return isLoading;
+}
+
+export function useStorage<T>(
+  key: string,
+  data: T,
+  setData: (data: T) => void,
+) {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const doLoadData = async () => {
+      const fromFile = await readFromFile<T>(key);
+      if (fromFile) {
+        setData(fromFile);
+        setIsLoading(false);
+        return;
+      }
+
+      const fromAsyncStore = await readFromAsyncStore<T>(key);
+      if (fromAsyncStore) {
+        await writeToFile<T>(key, fromAsyncStore);
+        setData(fromAsyncStore);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(false);
+    };
+
+    doLoadData();
+  }, []);
+
+  useEffect(() => {
+    const doStoreData = async () => {
+      await writeToFile<T>(key, data);
     };
 
     doStoreData();


### PR DESCRIPTION
Switch the storage module, to use file storage.

On read, if the file is not found or is empty, we fallback to using async storage.